### PR TITLE
Added error handling to chatbot response

### DIFF
--- a/src/components/userDashboard/clientChatbot/chat/fragments/AIConversationBlock.tsx
+++ b/src/components/userDashboard/clientChatbot/chat/fragments/AIConversationBlock.tsx
@@ -22,6 +22,12 @@ const AIConversationBlock: React.FC<AIConversationBlockProps> =({blockId, messag
     useEffect(() => {
         if (!message) return;
         
+        // If there's an error, show the full error message immediately
+        if (isError) {
+            setVisibleContent(message);
+            return;
+        }
+
         // Store the full message
         fullContentRef.current = message;
         
@@ -33,11 +39,11 @@ const AIConversationBlock: React.FC<AIConversationBlockProps> =({blockId, messag
             // For non-streaming (existing messages), show the full content immediately
             setVisibleContent(message);
         }
-    }, [message, isStreaming]);
+    }, [message, isStreaming, isError]);
 
     // Handle streaming effect
     useEffect(() => {
-        if (!isStreaming || !message) return;
+        if (!isStreaming || !message || isError) return;
         
         // If we're streaming and message is different from what's visible,
         // gradually reveal the content character by character
@@ -57,7 +63,7 @@ const AIConversationBlock: React.FC<AIConversationBlockProps> =({blockId, messag
                 return () => clearTimeout(timer);
             }
         }
-    }, [message, visibleContent, isStreaming]);
+    }, [message, visibleContent, isStreaming, isError]);
 
     
     // Actively animate the cursor during streaming
@@ -93,7 +99,7 @@ const AIConversationBlock: React.FC<AIConversationBlockProps> =({blockId, messag
                     ) : (
                         <div>
                             {displayContent ? <Markdown>{displayContent}</Markdown> : ""}
-                            {isStreaming && (
+                            {isStreaming && !isError && (
                                 <span className="typing-cursor"></span>
                             )}
                         </div>


### PR DESCRIPTION
## Description
AI Chatbot were reported as not working. Tested UI with fix/chat-and-rag-optimizations branch of the API and found that the chatbot was working with this version of the API but improved error handling in the event that responses do fail the UI doesn't break.

## Ticket Link
NA

## Changes Made
- Added isError as a dependency of the main useEffect of the AIConversationBlock.
- Added error handling to the main useEffect of the AIConversationBlock.
- Added isError as a dependecy of the streaming useEffect of the AIConversationBlock.
- Added isError to the condition to stop execution of the streaming useEffect logic.
- Added isError to the condition that renders the typing animation. When isError is true the typing animation will no longer show.
- Added isError to the condition that renders the streaming text to prevent it from showing after an error.

## Testing Instructions
- npm run start

## Checklist
- [ ] Linked ticket
- [ ] Code review comments addressed
- [ ] Unit tests added/updated